### PR TITLE
Disable Doclint for Java8 (for now?)

### DIFF
--- a/ontologizer/pom.xml
+++ b/ontologizer/pom.xml
@@ -257,6 +257,9 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
+				<configuration>
+					<additionalparam>-Xdoclint:none</additionalparam>
+				</configuration>
 				<version>2.10.3</version>
 				<executions>
 					<execution>


### PR DESCRIPTION
`mvn package` failed. Google found this:

http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html

Better alternative is updating the javadocs which fail. Which is why I added "for now".

I haven't tested if this is backwards compatible with older versions of Java.
