### PR TITLE
[Suggestion] add ignore obsolete functionality

### DIFF
--- a/ontologizer/src/ontologizer/ontology/OBOParser.java
+++ b/ontologizer/src/ontologizer/ontology/OBOParser.java
@@ -215,6 +215,10 @@ public class OBOParser
 		return this.terms;
 	}
 
+	public boolean ignoreObsoleteTerms()
+	{
+		return false;
+    	}
 	/**
 	 * This puts the results of the parse of a single OBO stanza into one Term
 	 * object and stores that in the HashSet terms.
@@ -239,20 +243,23 @@ public class OBOParser
 				return;
 
 			}
+			//Ignore term if both obsolete and we are ignoring obsoletes
+			if (!(ignoreObsoleteTerms() && this.currentObsolete))
+            		{
+				/* Create a Term object and put it in the HashMap terms. */
+				Term t = new Term(currentID, currentName, currentNamespace, currentParents);
+				t.setObsolete(currentObsolete);
+				t.setDefinition(currentDefintion);
+				t.setAlternatives(currentAlternatives);
+				t.setEquivalents(currentEquivalents);
+				t.setSubsets(currentSubsets);
+				t.setSynonyms(currentSynonyms);
+				t.setXrefs(currentXrefs);
+				terms.add(t);
 
-			/* Create a Term object and put it in the HashMap terms. */
-			Term t = new Term(currentID, currentName, currentNamespace, currentParents);
-			t.setObsolete(currentObsolete);
-			t.setDefinition(currentDefintion);
-			t.setAlternatives(currentAlternatives);
-			t.setEquivalents(currentEquivalents);
-			t.setSubsets(currentSubsets);
-			t.setSynonyms(currentSynonyms);
-			t.setXrefs(currentXrefs);
-			terms.add(t);
-
-			/* Statistics */
-			numberOfRelations += currentParents.size();
+				/* Statistics */
+				numberOfRelations += currentParents.size();
+			}
 		}
 
 		resetCurrentStanza();


### PR DESCRIPTION
I am not sure if the code currently has this functionality, but I think others might appreciate an option to ignore obsolete terms. For example, in my research, I choose to ignore obsolete terms because they are unnecessary. (The way I currently do this is a hacky and inefficient way where I loop through the term map and manually remove if it is obsolete). 

Also, this is only a suggestion, since I feel like we can ignore obsoletes at a lower level (i.e. at the file stream level) and save some time there. 